### PR TITLE
메인화면 리팩토링 phase2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,4 +157,8 @@ dependencies {
 
     //ffmpeg
     implementation("com.arthenica:ffmpeg-kit-full:6.0-2")
+
+    // Flow Binding
+    val flowbinding_version = "1.2.0"
+    implementation("io.github.reactivecircus.flowbinding:flowbinding-android:${flowbinding_version}")
 }

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/ChipUtil.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/ChipUtil.kt
@@ -12,9 +12,11 @@ fun createChip(context: Context, tag: String): Chip {
     chip.text = tag
     chip.setChipBackgroundColorResource(android.R.color.white)
 
-    // TODO: 추후 태그 문자열의 길이가 길어지는 경우도 대응해야함
-    val params = ViewGroup.LayoutParams(200, ViewGroup.LayoutParams.WRAP_CONTENT)
+    val params = ViewGroup.LayoutParams(context.dp2Px(78), ViewGroup.LayoutParams.WRAP_CONTENT)
     chip.layoutParams = params
+
+    val dp24 = context.dp2Px(24)
+    chip.setPadding(dp24, dp24, dp24, dp24)
     return chip
 }
 

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Context.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Context.kt
@@ -1,7 +1,11 @@
 package com.eighteen.eighteenandroid.presentation.common
 
 import android.content.Context
+import android.os.Build
+import android.util.DisplayMetrics
 import android.util.TypedValue
+import android.view.WindowInsets
+import android.view.WindowManager
 
 fun Context.dp2Px(dp: Float): Int =
     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics)
@@ -12,3 +16,18 @@ fun Context.dp2Px(dp: Int): Int = dp2Px(dp.toFloat())
 fun Context.px2DpF(px: Int): Float = px / resources.displayMetrics.density
 
 fun Context.px2Dp(px: Int): Int = px2DpF(px).toInt()
+
+/** 화면 가로 길이 구하기 */
+fun Context.getScreenWidth(): Int {
+    val wm = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val windowMetrics = wm.currentWindowMetrics
+        val insets = windowMetrics.windowInsets
+            .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())
+        windowMetrics.bounds.width() - insets.left - insets.right
+    } else {
+        val displayMetrics = DisplayMetrics()
+        wm.defaultDisplay.getMetrics(displayMetrics)
+        displayMetrics.widthPixels
+    }
+}

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Fragment.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Fragment.kt
@@ -2,11 +2,15 @@ package com.eighteen.eighteenandroid.presentation.common
 
 import android.content.Context
 import android.os.Parcelable
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.LinearLayout
+import android.widget.PopupWindow
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -35,6 +39,46 @@ fun showReportSelectDialog(context: Context, onReportClicked: () -> Unit, onBloc
         onBlockClicked()
         customAlertDialog.dismiss()
     }
+}
+
+/** 신고하기 & 차단하기 아이템 앵커뷰 */
+fun showReportSelectDialog(itemView: View, onReportClicked: () -> Unit, onBlockClicked: () -> Unit) {
+    val reportSelectDialogView = LayoutInflater.from(itemView.context).inflate(R.layout.dialog_report_select, null)
+    val displayMetrics = itemView.context.resources.displayMetrics
+
+    val popupWindow = PopupWindow(
+        reportSelectDialogView,
+        (displayMetrics.density * 145).toInt(),
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        true
+    )
+
+    // 팝업 메뉴 아이템에 대한 클릭 리스너 설정
+    reportSelectDialogView.findViewById<LinearLayoutCompat>(R.id.report_container).setOnClickListener {
+        onReportClicked()
+        popupWindow.dismiss()
+    }
+
+    reportSelectDialogView.findViewById<LinearLayoutCompat>(R.id.block_container).setOnClickListener {
+        onBlockClicked()
+        popupWindow.dismiss()
+    }
+
+    // 팝업 뷰의 크기 측정
+    reportSelectDialogView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    val popupWidth = reportSelectDialogView.measuredWidth
+
+    // X 오프셋 계산 (버튼 왼쪽에 표시)
+    val xOffset = -popupWidth - itemView.width -(displayMetrics.density * 18.5).toInt()
+
+    // Y 오프셋 계산 (버튼과 상단을 맞춤)
+    val yOffset = -itemView.height
+
+    // 팝업 창 표시
+    popupWindow.showAsDropDown(itemView, xOffset, yOffset - itemView.height)
+
+    // 팝업 창 표시
+//    popupWindow.showAsDropDown(itemView)
 }
 
 fun <T : Parcelable> Fragment.getNavigationResult(key: String) =

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Fragment.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/Fragment.kt
@@ -22,33 +22,13 @@ fun Fragment.showDialogFragment(dialogFragment: DialogFragment, tag: String? = n
     dialogFragment.show(childFragmentManager, tag)
 }
 
-/** 신고하기 & 차단하기 선택 다이얼로그 */
-fun showReportSelectDialog(context: Context, onReportClicked: () -> Unit, onBlockClicked: () -> Unit) {
-    val reportSelectBinding = DialogReportSelectBinding.inflate(LayoutInflater.from(context))
-    val customAlertDialog = AlertDialog.Builder(context, R.style.CustomDialog)
-        .setView(reportSelectBinding.root)
-        .create()
-
-    customAlertDialog.show()
-    reportSelectBinding.reportContainer.setOnClickListener {
-        onReportClicked()
-        customAlertDialog.dismiss()
-    }
-
-    reportSelectBinding.blockContainer.setOnClickListener {
-        onBlockClicked()
-        customAlertDialog.dismiss()
-    }
-}
-
-/** 신고하기 & 차단하기 아이템 앵커뷰 */
-fun showReportSelectDialog(itemView: View, onReportClicked: () -> Unit, onBlockClicked: () -> Unit) {
+/** 신고하기 & 차단하기 아이템 앵커뷰 Left */
+fun showReportSelectDialogLeft(itemView: View, onReportClicked: () -> Unit, onBlockClicked: () -> Unit) {
     val reportSelectDialogView = LayoutInflater.from(itemView.context).inflate(R.layout.dialog_report_select, null)
-    val displayMetrics = itemView.context.resources.displayMetrics
 
     val popupWindow = PopupWindow(
         reportSelectDialogView,
-        (displayMetrics.density * 145).toInt(),
+        (itemView.context.dp2Px(145)),
         LinearLayout.LayoutParams.WRAP_CONTENT,
         true
     )
@@ -68,17 +48,43 @@ fun showReportSelectDialog(itemView: View, onReportClicked: () -> Unit, onBlockC
     reportSelectDialogView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
     val popupWidth = reportSelectDialogView.measuredWidth
 
-    // X 오프셋 계산 (버튼 왼쪽에 표시)
-    val xOffset = -popupWidth - itemView.width -(displayMetrics.density * 18.5).toInt()
-
-    // Y 오프셋 계산 (버튼과 상단을 맞춤)
-    val yOffset = -itemView.height
+    val xOffset = -popupWidth - itemView.width - (itemView.context.dp2Px(18))
+    val yOffset = - (itemView.height * 2)
 
     // 팝업 창 표시
-    popupWindow.showAsDropDown(itemView, xOffset, yOffset - itemView.height)
+    popupWindow.showAsDropDown(itemView, xOffset, yOffset)
+}
+
+/** 신고하기 & 차단하기 아이템 앵커뷰 Left */
+fun showReportSelectDialogBottom(itemView: View, onReportClicked: () -> Unit, onBlockClicked: () -> Unit) {
+    val reportSelectDialogView = LayoutInflater.from(itemView.context).inflate(R.layout.dialog_report_select, null)
+
+    val popupWindow = PopupWindow(
+        reportSelectDialogView,
+        (itemView.context.dp2Px(145)),
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        true
+    )
+
+    // 팝업 메뉴 아이템에 대한 클릭 리스너 설정
+    reportSelectDialogView.findViewById<LinearLayoutCompat>(R.id.report_container).setOnClickListener {
+        onReportClicked()
+        popupWindow.dismiss()
+    }
+
+    reportSelectDialogView.findViewById<LinearLayoutCompat>(R.id.block_container).setOnClickListener {
+        onBlockClicked()
+        popupWindow.dismiss()
+    }
+
+    // 팝업 뷰의 크기 측정
+    reportSelectDialogView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+    val popupWidth = reportSelectDialogView.measuredWidth
+
+    val xOffset = -popupWidth
 
     // 팝업 창 표시
-//    popupWindow.showAsDropDown(itemView)
+    popupWindow.showAsDropDown(itemView, xOffset, 0)
 }
 
 fun <T : Parcelable> Fragment.getNavigationResult(key: String) =

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/View.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/common/View.kt
@@ -1,0 +1,27 @@
+package com.eighteen.eighteenandroid.presentation.common
+
+import android.view.View
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import reactivecircus.flowbinding.android.view.clicks
+
+/** Flow Binding Clicks */
+fun View.throttleClick(scope: CoroutineScope, duration: Long = 700L,func: () -> Unit) {
+    this.clicks().throttleFirst(duration).onEach { func() }.launchIn(scope)    // FlowBinding ThrottleClick
+}
+
+/** 중복 클릭 방지 */
+fun <T> Flow<T>.throttleFirst(duration: Long): Flow<T> = flow {
+    var lastEmissionTime = 0L
+
+    collect { upstream ->
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastEmissionTime > duration) {
+            lastEmissionTime = currentTime
+            emit(upstream)
+        }
+    }
+}

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainFragment.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainFragment.kt
@@ -281,7 +281,7 @@ class MainFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
 
             override fun startAutoScroll(rvMainTeenPopularList: RecyclerView) {
                 isAutoScrolling = true
-                autoScrollJob = lifecycleScope.launch {
+                autoScrollJob = viewLifecycleOwner.lifecycleScope.launch {
                     val smoothScroller = object : LinearSmoothScroller(requireContext()) {
                         override fun getVerticalSnapPreference(): Int {
                             return SNAP_TO_START
@@ -498,15 +498,5 @@ class MainFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
                 }
             }
         }
-    }
-
-    override fun onDestroy() {
-        mainAdapterListener.stopAutoScroll()
-        super.onDestroy()
-    }
-
-    override fun onDestroyView() {
-        mainAdapterListener.stopAutoScroll()
-        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainFragment.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainFragment.kt
@@ -5,6 +5,7 @@ import android.widget.ImageView
 import androidx.fragment.app.viewModels
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.eighteen.eighteenandroid.R
 import com.eighteen.eighteenandroid.common.enums.Tag
@@ -152,7 +153,17 @@ class MainFragment : BaseFragment<FragmentMainBinding>(FragmentMainBinding::infl
              * 이전에 보던 인기 Teen 유저로 이동
              */
             override fun scrollToPreviousUser(recyclerView: RecyclerView) {
-                recyclerView.smoothScrollToPosition(viewModel.savedPosition)
+                val layoutManager = recyclerView.layoutManager as LinearLayoutManager
+                layoutManager.scrollToPositionWithOffset(viewModel.savedPosition, 0)
+
+                // 부드러운 스크롤을 위해 post 사용
+                recyclerView.post {
+                    val targetView = layoutManager.findViewByPosition(viewModel.savedPosition)
+                    if (targetView != null) {
+                        val offset = recyclerView.width / 2 - targetView.width / 2
+                        layoutManager.scrollToPositionWithOffset(viewModel.savedPosition, offset)
+                    }
+                }
             }
 
             /**

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainViewModel.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/MainViewModel.kt
@@ -5,15 +5,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.bumptech.glide.Glide.init
 import com.eighteen.eighteenandroid.domain.model.User
 import com.eighteen.eighteenandroid.domain.usecase.UserUseCase
 import com.eighteen.eighteenandroid.presentation.home.adapter.MainItem
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,7 +18,8 @@ class MainViewModel @Inject constructor(
     private val userUseCase: UserUseCase
 ) : ViewModel() {
 
-    var savedPosition = 0
+    var popularUserPosition = 0
+    var pageScrollPosition = 0
 
     private val _userData = MutableLiveData<List<User>>()
     val userData: LiveData<List<User>> = _userData

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/AboutTeenAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/AboutTeenAdapter.kt
@@ -2,6 +2,7 @@ package com.eighteen.eighteenandroid.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.eighteen.eighteenandroid.R
@@ -9,9 +10,14 @@ import com.eighteen.eighteenandroid.databinding.ItemAboutTeenBinding
 import com.eighteen.eighteenandroid.domain.model.AboutTeen
 import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.AboutTeenDiffCallBack
 
-class AboutTeenAdapter: ListAdapter<AboutTeen, AboutTeenAdapter.AboutTeenViewHolder>(AboutTeenDiffCallBack()) {
+class AboutTeenAdapter(
+    private val listener: MainAdapterListener
+): ListAdapter<AboutTeen, AboutTeenAdapter.AboutTeenViewHolder>(AboutTeenDiffCallBack()) {
 
-    class AboutTeenViewHolder(private val binding: ItemAboutTeenBinding): RecyclerView.ViewHolder(binding.root) {
+    class AboutTeenViewHolder(
+        private val binding: ItemAboutTeenBinding,
+        private val listener: MainAdapterListener
+    ): RecyclerView.ViewHolder(binding.root) {
         fun bind(item: AboutTeen) {
             with(binding) {
                 tvAboutTeenTitle.text = item.title
@@ -22,6 +28,10 @@ class AboutTeenAdapter: ListAdapter<AboutTeen, AboutTeenAdapter.AboutTeenViewHol
                     "토너먼트", "채팅" -> imgAboutTeen.setImageResource(R.drawable.ic_chat)
                     "나만의 Teen" -> imgAboutTeen.setImageResource(R.drawable.ic_my_teen)
                 }
+
+                root.setOnClickListener {
+                    listener.onAboutTeenClicks(item.title)
+                }
             }
         }
     }
@@ -29,7 +39,7 @@ class AboutTeenAdapter: ListAdapter<AboutTeen, AboutTeenAdapter.AboutTeenViewHol
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AboutTeenViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val itemBinding = ItemAboutTeenBinding.inflate(layoutInflater, parent, false)
-        return AboutTeenViewHolder(itemBinding)
+        return AboutTeenViewHolder(itemBinding, listener)
     }
 
     override fun onBindViewHolder(holder: AboutTeenViewHolder, position: Int) {

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/MainAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/MainAdapter.kt
@@ -207,26 +207,26 @@ class MainAdapter(
                     snapHelper.attachToRecyclerView(rvMainTeenPopularList)
 
                     val teenAdapter = TeenAdapter(context, listener)
-                    rvMainTeenPopularList.adapter = teenAdapter
+                    with(rvMainTeenPopularList) {
+                        adapter = teenAdapter
 
-                    rvMainTeenPopularList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
-                            super.onScrollStateChanged(recyclerView, newState)
-                            if (newState == RecyclerView.SCROLL_STATE_IDLE) {
-                                val layoutManager = recyclerView.layoutManager
-                                val centerView = snapHelper.findSnapView(layoutManager)
-                                val pos = centerView?.let { layoutManager?.getPosition(it) }
-                                pos?.let {
-                                    // 페이지가 변경될 때마다 이 위치(pos)를 사용하여 원하는 작업을 수행
-                                    if(it > 0) listener.saveUserPosition(it)
+                        addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                                super.onScrollStateChanged(recyclerView, newState)
+                                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                                    val layoutManager = recyclerView.layoutManager
+                                    val centerView = snapHelper.findSnapView(layoutManager)
+                                    val pos = centerView?.let { layoutManager?.getPosition(it) }
+                                    pos?.let {
+                                        // 페이지가 변경될 때마다 이 위치(pos)를 사용하여 원하는 작업을 수행
+                                        listener.saveUserPosition(it)
+                                    }
                                 }
                             }
-                        }
-                    })
-
-                    listener.scrollToPreviousUser(rvMainTeenPopularList)
-
+                        })
+                    }
                     teenAdapter.submitList(userListView?.userList)
+                    listener.scrollToPreviousUser(rvMainTeenPopularList)
                 }
             }
         }

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/MainAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/MainAdapter.kt
@@ -1,11 +1,10 @@
 package com.eighteen.eighteenandroid.presentation.home.adapter
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnLayout
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
@@ -46,7 +45,7 @@ interface MainAdapterListener {
     fun onTournamentMoreClicks()
 
     /** 이전에 보여진 유저 스크롤 */
-    fun scrollToPreviousUser(recyclerView: RecyclerView)
+    fun scrollToPreviousUser()
 
     /** 이전에 보여진 유저 포지션 저장*/
     fun saveUserPosition(position: Int)
@@ -54,7 +53,7 @@ interface MainAdapterListener {
     /** 현재 메인화면 스크롤 포지션 저장*/
     fun saveScrollPosition(position: Int)
 
-    fun startAutoScroll(rvMainTeenPopularList: RecyclerView)
+    fun startAutoScroll()
 
     fun stopAutoScroll()
 }
@@ -200,7 +199,7 @@ class MainAdapter(
 
         class PopularUserListViewHolder(
             private val context: Context,
-            private val binding: ItemMainPopularTeenListviewBinding,
+            val binding: ItemMainPopularTeenListviewBinding,
             private val listener: MainAdapterListener
         ) : CommonViewHolder(binding) {
             private val snapHelper = PagerSnapHelper()
@@ -234,7 +233,7 @@ class MainAdapter(
                                             // 페이지가 변경될 때마다 이 위치(pos)를 사용하여 원하는 작업을 수행
                                             listener.saveUserPosition(it)
                                             listener.stopAutoScroll()
-                                            listener.startAutoScroll(rvMainTeenPopularList)
+                                            listener.startAutoScroll()
                                         }
                                     }
                                 }
@@ -242,8 +241,11 @@ class MainAdapter(
                         })
                     }
 
-                    popularUserAdapter.submitList(userListView?.userList)
-                    listener.scrollToPreviousUser(rvMainTeenPopularList)
+                    popularUserAdapter.submitList(userListView?.userList) {
+                        rvMainTeenPopularList.doOnLayout {
+                            listener.scrollToPreviousUser()
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
@@ -9,6 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.eighteen.eighteenandroid.databinding.ItemPopularTeenBinding
 import com.eighteen.eighteenandroid.domain.model.User
+import com.eighteen.eighteenandroid.presentation.common.dp2Px
+import com.eighteen.eighteenandroid.presentation.common.getScreenWidth
 import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.UserDiffCallBack
 
 /**
@@ -40,6 +42,11 @@ class PopularUserAdapter(
 
         @SuppressLint("SetTextI18n")
         fun bind(user: User, context: Context) {
+            val layoutParams = itemView.layoutParams
+            layoutParams.width = context.getScreenWidth() - context.dp2Px(60)
+            layoutParams.height = context.getScreenWidth() - context.dp2Px(60)
+            itemView.layoutParams = layoutParams
+
             binding.run {
                 Glide.with(context).load(user.userImage).into(imgTodayTeen)
                 tvName.text = "${user.userName}, ${user.userAge}"

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
@@ -4,12 +4,9 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.eighteen.eighteenandroid.R
 import com.eighteen.eighteenandroid.databinding.ItemPopularTeenBinding
 import com.eighteen.eighteenandroid.domain.model.User
 import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.UserDiffCallBack
@@ -20,10 +17,10 @@ import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.UserD
  * @date 05/08/2024
  * 오늘의 Teen & 또다른 Teen 목록에 대한 RecyclerView Adapter
  */
-class TeenAdapter(
+class PopularUserAdapter(
     private val context: Context,
     private val mainAdapterListener: MainAdapterListener
-) : ListAdapter<User, TeenAdapter.TeenViewHolder>(UserDiffCallBack()) {
+) : ListAdapter<User, PopularUserAdapter.TeenViewHolder>(UserDiffCallBack()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeenViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -48,8 +45,16 @@ class TeenAdapter(
                 tvName.text = "${user.userName}, ${user.userAge}"
                 tvSchool.text = user.userSchoolName
 
-                binding.imgTodayTeen.setOnClickListener {
+                imgTodayTeen.setOnClickListener {
                     mainAdapterListener.onUserClicks(user)
+                }
+
+                btnChat.setOnClickListener {
+                    mainAdapterListener.onUserChatClicks(user)
+                }
+
+                btnLike.setOnClickListener {
+                    mainAdapterListener.onUserLikeClicks(user)
                 }
 
                 btnSetting.setOnClickListener {

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/PopularUserAdapter.kt
@@ -12,6 +12,7 @@ import com.eighteen.eighteenandroid.domain.model.User
 import com.eighteen.eighteenandroid.presentation.common.dp2Px
 import com.eighteen.eighteenandroid.presentation.common.getScreenWidth
 import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.UserDiffCallBack
+import kotlin.math.roundToInt
 
 /**
  *
@@ -43,8 +44,9 @@ class PopularUserAdapter(
         @SuppressLint("SetTextI18n")
         fun bind(user: User, context: Context) {
             val layoutParams = itemView.layoutParams
-            layoutParams.width = context.getScreenWidth() - context.dp2Px(60)
-            layoutParams.height = context.getScreenWidth() - context.dp2Px(60)
+            val itemWidth = context.getScreenWidth() - (context.getScreenWidth() * 0.07 * 2).roundToInt()
+            layoutParams.width = itemWidth          // 0.85
+            layoutParams.height = itemWidth * 100 / 85  // 1
             itemView.layoutParams = layoutParams
 
             binding.run {

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/TeenAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/TeenAdapter.kt
@@ -22,14 +22,14 @@ import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.UserD
  */
 class TeenAdapter(
     private val context: Context,
-    private val showUserReportSelectDialog:(User) -> Unit
+    private val mainAdapterListener: MainAdapterListener
 ) : ListAdapter<User, TeenAdapter.TeenViewHolder>(UserDiffCallBack()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeenViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val itemBinding = ItemPopularTeenBinding.inflate(layoutInflater, parent,false)
 
-        return TeenViewHolder(itemBinding, showUserReportSelectDialog)
+        return TeenViewHolder(itemBinding, mainAdapterListener)
     }
 
     override fun onBindViewHolder(holder: TeenViewHolder, position: Int) {
@@ -38,29 +38,24 @@ class TeenAdapter(
 
     class TeenViewHolder(
         private val binding: ItemPopularTeenBinding,
-        private val showUserReportSelectDialog: (User) -> Unit
+        private val mainAdapterListener: MainAdapterListener
     ) : RecyclerView.ViewHolder(binding.root) {
 
         @SuppressLint("SetTextI18n")
-        fun bind(item: User, context: Context) {
+        fun bind(user: User, context: Context) {
             binding.run {
-                Glide.with(context).load(item.userImage).into(imgTodayTeen)
-                tvName.text = "${item.userName}, ${item.userAge}"
-                tvSchool.text = item.userSchoolName
-                initNavigation(binding.imgTodayTeen)
+                Glide.with(context).load(user.userImage).into(imgTodayTeen)
+                tvName.text = "${user.userName}, ${user.userAge}"
+                tvSchool.text = user.userSchoolName
+
+                binding.imgTodayTeen.setOnClickListener {
+                    mainAdapterListener.onUserClicks(user)
+                }
+
                 btnSetting.setOnClickListener {
-                    showUserReportSelectDialog(item)
+                    mainAdapterListener.onUserMoreClicks(btnSetting, user)
                 }
             }
         }
-
-        /** 유저 상세로 이동 Navigation */
-        private fun initNavigation(profileImageView: ImageView) {
-            profileImageView.setOnClickListener { view ->
-                val navController = Navigation.findNavController(view)
-                navController.navigate(R.id.action_fragmentMain_to_fragmentProfileDetail)
-            }
-        }
-
     }
 }

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/TournamentAdapter.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/home/adapter/TournamentAdapter.kt
@@ -8,18 +8,27 @@ import com.eighteen.eighteenandroid.R
 import com.eighteen.eighteenandroid.databinding.ItemTournamentBinding
 import com.eighteen.eighteenandroid.presentation.home.adapter.diffcallback.TournamentDiffCallBack
 
-class TournamentAdapter: ListAdapter<Tournament, TournamentAdapter.TournamentViewHolder>(TournamentDiffCallBack()) {
+class TournamentAdapter(
+    private val listener: MainAdapterListener
+): ListAdapter<Tournament, TournamentAdapter.TournamentViewHolder>(TournamentDiffCallBack()) {
 
-    class TournamentViewHolder(private val binding: ItemTournamentBinding): RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: Tournament) {
+    class TournamentViewHolder(
+        private val binding: ItemTournamentBinding,
+        private val listener: MainAdapterListener
+    ): RecyclerView.ViewHolder(binding.root) {
+        fun bind(tournament: Tournament) {
             with(binding) {
-                when(item) {
+                when(tournament) {
                     is Tournament.Exercise -> {
                         ivTournament.setImageResource(R.drawable.bg_tournament_exercise)
                     }
                     is Tournament.Study -> {
                         ivTournament.setImageResource(R.drawable.bg_tournament_study)
                     }
+                }
+
+                root.setOnClickListener {
+                    listener.onTournamentClicks(tournament)
                 }
             }
         }
@@ -29,7 +38,7 @@ class TournamentAdapter: ListAdapter<Tournament, TournamentAdapter.TournamentVie
         val layoutInflater = LayoutInflater.from(parent.context)
         val itemBinding = ItemTournamentBinding.inflate(layoutInflater, parent, false)
 
-        return TournamentViewHolder(itemBinding)
+        return TournamentViewHolder(itemBinding, listener)
     }
 
     override fun onBindViewHolder(holder: TournamentViewHolder, position: Int) {

--- a/app/src/main/java/com/eighteen/eighteenandroid/presentation/mediadetail/MediaDetailDialogFragment.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/presentation/mediadetail/MediaDetailDialogFragment.kt
@@ -14,7 +14,7 @@ import com.eighteen.eighteenandroid.databinding.FragmentMediaDetailDialogBinding
 import com.eighteen.eighteenandroid.presentation.BaseDialogFragment
 import com.eighteen.eighteenandroid.presentation.common.media3.viewpager2.ViewPagerPlayerManager
 import com.eighteen.eighteenandroid.presentation.common.showDialogFragment
-import com.eighteen.eighteenandroid.presentation.common.showReportSelectDialog
+import com.eighteen.eighteenandroid.presentation.common.showReportSelectDialogBottom
 import com.eighteen.eighteenandroid.presentation.dialog.ReportDialogFragment
 import kotlinx.coroutines.launch
 
@@ -58,8 +58,8 @@ class MediaDetailDialogFragment :
             }
             ivBtnOption.setOnClickListener {
                 context?.let {
-                    showReportSelectDialog(
-                        context = it,
+                    showReportSelectDialogBottom(
+                        ivBtnOption,
                         onReportClicked = {
                             // 신고 다이얼로그 보여주기
                             // TODO. 유저 정보 필요

--- a/app/src/main/res/drawable/bg_oval_stroke_w1_grey_03.xml
+++ b/app/src/main/res/drawable/bg_oval_stroke_w1_grey_03.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_03" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_scroll_top.xml
+++ b/app/src/main/res/drawable/ic_scroll_top.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="20dp"
+    android:viewportWidth="19"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M1,10.485L9.485,2L17.971,10.485"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#5258EE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.485,18.971C8.485,19.523 8.933,19.971 9.485,19.971C10.038,19.971 10.485,19.523 10.485,18.971L8.485,18.971ZM8.485,2V18.971L10.485,18.971V2L8.485,2Z"
+      android:fillColor="#5258EE"/>
+</vector>

--- a/app/src/main/res/layout/dialog_report_select.xml
+++ b/app/src/main/res/layout/dialog_report_select.xml
@@ -3,9 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="144dp"
     android:layout_height="wrap_content"
-    app:cardCornerRadius="20dp"
-    app:strokeColor="@color/grey_03"
-    app:strokeWidth="2dp">
+    app:cardCornerRadius="20dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_report_select.xml
+++ b/app/src/main/res/layout/dialog_report_select.xml
@@ -5,7 +5,8 @@
     android:layout_height="wrap_content"
     app:cardCornerRadius="20dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -35,6 +36,10 @@
 
         </androidx.appcompat.widget.LinearLayoutCompat>
 
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/grey_03"/>
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:id="@+id/block_container"
@@ -62,6 +67,6 @@
 
         </androidx.appcompat.widget.LinearLayoutCompat>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -28,20 +28,20 @@
             android:id="@+id/btn_search"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_search"
             android:layout_marginEnd="20dp"
-            app:layout_constraintTop_toTopOf="@id/btn_notification"
-            app:layout_constraintEnd_toStartOf="@id/btn_notification" />
+            android:src="@drawable/ic_search"
+            app:layout_constraintEnd_toStartOf="@id/btn_notification"
+            app:layout_constraintTop_toTopOf="@id/btn_notification" />
 
         <ImageView
             android:id="@+id/btn_notification"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
             android:layout_marginTop="40dp"
+            android:layout_marginEnd="16dp"
             android:src="@drawable/ic_notification"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
@@ -89,5 +89,19 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/sv_main_tag_chip" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/btn_scroll_top"
+        android:layout_width="47dp"
+        android:layout_height="47dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="24dp"
+        android:background="@drawable/bg_oval_stroke_w1_grey_03"
+        android:elevation="4dp"
+        android:focusable="true"
+        android:scaleType="center"
+        android:src="@drawable/ic_scroll_top"
+        app:layout_constraintBottom_toBottomOf="@+id/rv_main"
+        app:layout_constraintEnd_toEndOf="@+id/rv_main" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,101 +7,104 @@
     android:background="@color/background_color"
     tools:context=".presentation.home.MainFragment">
 
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_color"
+        android:outlineProvider="none">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/background_color"
+            app:layout_scrollFlags="scroll|enterAlways|snap">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:paddingTop="40dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_logo"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/btn_search"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_search"
+                    app:layout_constraintEnd_toStartOf="@id/btn_notification"
+                    app:layout_constraintTop_toTopOf="@id/btn_notification" />
+
+                <ImageView
+                    android:id="@+id/btn_notification"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:src="@drawable/ic_notification"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <HorizontalScrollView
+            android:id="@+id/sv_main_tag_chip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginVertical="12dp"
+            android:scrollbars="none">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chip_group"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@color/white"
+                android:textAlignment="center"
+                app:chipCornerRadius="20dp"
+                app:chipStrokeColor="@color/black"
+                app:chipStrokeWidth="1dp" />
+        </HorizontalScrollView>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/media_detail_header_height"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="40dp"
-            android:layout_marginBottom="10dp"
-            android:src="@drawable/ic_logo"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_main"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="8dp"
+            android:orientation="vertical"
+            android:overScrollMode="never"
+            android:paddingBottom="20dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/btn_search"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="20dp"
-            android:src="@drawable/ic_search"
-            app:layout_constraintEnd_toStartOf="@id/btn_notification"
-            app:layout_constraintTop_toTopOf="@id/btn_notification" />
-
-        <ImageView
-            android:id="@+id/btn_notification"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="40dp"
-            android:layout_marginEnd="16dp"
-            android:src="@drawable/ic_notification"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <TextView
-        android:id="@+id/tv_today_teen"
-        style="@style/pretendard_bold_20"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="28dp"
-        android:text="@string/main_today_teen"
-        android:textAlignment="textStart"
-        android:textColor="@color/black"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
-
-    <HorizontalScrollView
-        android:id="@+id/sv_main_tag_chip"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="22dp"
-        android:scrollbars="none"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_today_teen">
-
-        <com.google.android.material.chip.ChipGroup
-            android:id="@+id/chip_group"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/white"
-            android:textAlignment="center"
-            app:chipCornerRadius="16dp"
-            app:chipStrokeColor="@color/black"
-            app:chipStrokeWidth="1dp" />
-    </HorizontalScrollView>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_main"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginHorizontal="8dp"
-        android:orientation="vertical"
-        android:paddingVertical="20dp"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/sv_main_tag_chip" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/btn_scroll_top"
         android:layout_width="47dp"
         android:layout_height="47dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="24dp"
         android:background="@drawable/bg_oval_stroke_w1_grey_03"
         android:elevation="4dp"
         android:focusable="true"
         android:scaleType="center"
+        android:layout_margin="16dp"
         android:src="@drawable/ic_scroll_top"
-        app:layout_constraintBottom_toBottomOf="@+id/rv_main"
-        app:layout_constraintEnd_toEndOf="@+id/rv_main" />
+        android:visibility="gone"
+        android:layout_gravity="bottom|right" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_main_popular_teen_listview.xml
+++ b/app/src/main/res/layout/item_main_popular_teen_listview.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="wrap_content">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_main_teen_popular_list"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="match_parent"
-        android:layout_height="381dp"
-        android:layout_marginStart="16dp"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        android:layout_height="wrap_content"
         android:orientation="horizontal"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:listitem="@layout/item_popular_teen" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_main_tag_chip.xml
+++ b/app/src/main/res/layout/item_main_tag_chip.xml
@@ -4,6 +4,8 @@
     android:layout_width="200dp"
     android:layout_height="wrap_content"
     android:textAlignment="center"
-    app:chipCornerRadius="16dp"
+    app:chipCornerRadius="20dp"
+    android:textSize="14sp"
+    android:fontFamily="@font/pretendard_regular"
     app:chipStrokeColor="@color/black"
     app:chipStrokeWidth="1dp" />

--- a/app/src/main/res/layout/item_popular_teen.xml
+++ b/app/src/main/res/layout/item_popular_teen.xml
@@ -21,13 +21,8 @@
 
         <ImageView
             android:layout_width="match_parent"
-            android:layout_height="144dp"
-            android:src="@drawable/bg_gradient_top"
-            app:layout_constraintTop_toTopOf="@+id/img_today_teen" />
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="144dp"
+            android:layout_height="0dp"
+            app:layout_constraintHeight_percent="0.7"
             android:src="@drawable/bg_gradient_bottom"
             app:layout_constraintBottom_toBottomOf="@+id/img_today_teen" />
 

--- a/app/src/main/res/layout/item_popular_teen.xml
+++ b/app/src/main/res/layout/item_popular_teen.xml
@@ -1,95 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="310dp"
-    android:layout_height="361dp">
+    android:id="@+id/cardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="20dp">
 
-    <androidx.cardview.widget.CardView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="8dp"
-        app:cardCornerRadius="20dp">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/img_today_teen"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            tools:src="@drawable/ic_teen_dummy" />
 
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/img_today_teen"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scaleType="centerCrop"
-                tools:src="@drawable/ic_teen_dummy" />
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="144dp"
+            android:src="@drawable/bg_gradient_top"
+            app:layout_constraintTop_toTopOf="@+id/img_today_teen" />
 
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="144dp"
-                android:src="@drawable/bg_gradient_top"
-                app:layout_constraintTop_toTopOf="@+id/img_today_teen" />
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="144dp"
+            android:src="@drawable/bg_gradient_bottom"
+            app:layout_constraintBottom_toBottomOf="@+id/img_today_teen" />
 
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="144dp"
-                android:src="@drawable/bg_gradient_bottom"
-                app:layout_constraintBottom_toBottomOf="@+id/img_today_teen" />
+        <TextView
+            android:id="@+id/tv_name"
+            style="@style/pretendard_bold_20"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toTopOf="@+id/tv_school"
+            app:layout_constraintStart_toStartOf="@id/tv_school"
+            tools:text="김 에스더, 16" />
 
-            <TextView
-                android:id="@+id/tv_name"
-                style="@style/pretendard_bold_20"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toTopOf="@+id/tv_school"
-                app:layout_constraintStart_toStartOf="@id/tv_school"
-                tools:text="김 에스더, 16" />
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_school"
+            style="@style/pretendard_regular_13"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginBottom="12dp"
+            android:drawableStart="@drawable/ic_profile_school"
+            android:drawablePadding="4dp"
+            android:gravity="center"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="@id/btn_setting"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="서울 중학교" />
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/tv_school"
-                style="@style/pretendard_regular_13"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginBottom="12dp"
-                android:drawableStart="@drawable/ic_profile_school"
-                android:drawablePadding="4dp"
-                android:gravity="center"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="@id/btn_setting"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:text="서울 중학교" />
+        <ImageButton
+            android:id="@+id/btn_chat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="#00ff0000"
+            android:src="@drawable/ic_profile_chat_btn"
+            app:layout_constraintBottom_toTopOf="@id/btn_like"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-            <ImageButton
-                android:id="@+id/btn_chat"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="#00ff0000"
-                android:src="@drawable/ic_profile_chat_btn"
-                app:layout_constraintBottom_toTopOf="@id/btn_like"
-                app:layout_constraintEnd_toEndOf="parent" />
+        <ImageButton
+            android:id="@+id/btn_like"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="#00ff0000"
+            android:src="@drawable/ic_profile_like_btn"
+            app:layout_constraintBottom_toTopOf="@id/btn_setting"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-            <ImageButton
-                android:id="@+id/btn_like"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="#00ff0000"
-                android:src="@drawable/ic_profile_like_btn"
-                app:layout_constraintBottom_toTopOf="@id/btn_setting"
-                app:layout_constraintEnd_toEndOf="parent" />
+        <ImageButton
+            android:id="@+id/btn_setting"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="26dp"
+            android:background="#00ff0000"
+            android:padding="12dp"
+            android:src="@drawable/ic_profile_setting_btn"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/btn_like"
+            app:layout_constraintStart_toStartOf="@id/btn_like" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <ImageButton
-                android:id="@+id/btn_setting"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
-                android:layout_marginBottom="26dp"
-                android:background="#00ff0000"
-                android:padding="12dp"
-                android:src="@drawable/ic_profile_setting_btn"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="@id/btn_like"
-                app:layout_constraintStart_toStartOf="@id/btn_like" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </androidx.cardview.widget.CardView>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_teen.xml
+++ b/app/src/main/res/layout/item_teen.xml
@@ -29,13 +29,8 @@
 
             <ImageView
                 android:layout_width="match_parent"
-                android:layout_height="144dp"
-                android:src="@drawable/bg_gradient_top"
-                app:layout_constraintTop_toTopOf="@+id/img_today_teen" />
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="144dp"
+                android:layout_height="0dp"
+                app:layout_constraintHeight_percent="0.7"
                 android:src="@drawable/bg_gradient_bottom"
                 app:layout_constraintBottom_toBottomOf="@+id/img_today_teen" />
 


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #55

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 메인 어댑터 람다식, 리스너 인터페이스로 변경
- 신고, 차단 다이얼로그 Anchor View로 보여지게 수정
- 메인화면 탑 버튼
- 스크롤에 따른 메인화면 탑 버튼 visibility 설정
- 신고, 차단 팝업 showReportSelectLeft
- 신고, 차단 팝업 showReportSelectBottom
- 중복 클릭 방지를 위한 Flow Binding 적용
- 메인화면 스크롤 상태 유지
- 카테고리 태그 버튼 크기 조절
- 인기 Teen 유저 아이템 크기 조정
- 인기 Teen 자동 스크롤