### PR TITLE
import 에러 수정 및 StartDestination 복원 #95

### DIFF
--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/fragmentRanking">
+    app:startDestination="@id/fragmentMain">
     <fragment
         android:id="@+id/fragmentLogin"
         android:name="com.eighteen.eighteenandroid.presentation.auth.LoginFragment"
@@ -158,7 +158,7 @@
         tools:layout="@layout/fragment_voting" />
     <fragment
         android:id="@+id/fragmentVotingComplete"
-        android:name="com.eighteen.eighteenandroid.presentation.ranking.voting.VotingCompleteFragment"
+        android:name="com.eighteen.eighteenandroid.presentation.ranking.votingComplete.VotingCompleteFragment"
         android:label="fragment_voting_complete"
         tools:layout="@layout/fragment_voting_complete" />
 


### PR DESCRIPTION
## 💡 관련 이슈
close #90 

## 🌱 변경 사항 및 이유
- #90 머지 시, nav_graph의 startDestination이 fragmentMain으로 복원되지 않은 상태로 머지되어 이를 복원했습니다.
- nav_graph에서 fragment name을 Import하는 부분에서 에러가 발생하여 이를 수정했습니다.