### PR TITLE
collectOnce 추가

### DIFF
--- a/app/src/main/java/com/eighteen/eighteenandroid/common/FlowUtils.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/common/FlowUtils.kt
@@ -1,0 +1,16 @@
+package com.eighteen.eighteenandroid.common
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.launch
+
+suspend fun <T> Flow<T>.collectOnce(coroutineScope: CoroutineScope, collect: (T) -> Unit) {
+    coroutineScope.launch {
+        this@collectOnce.cancellable().collect {
+            collect(it)
+            this.cancel()
+        }
+    }
+}

--- a/app/src/main/java/com/eighteen/eighteenandroid/common/FlowUtils.kt
+++ b/app/src/main/java/com/eighteen/eighteenandroid/common/FlowUtils.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.launch
 
-suspend fun <T> Flow<T>.collectOnce(coroutineScope: CoroutineScope, collect: (T) -> Unit) {
+fun <T> Flow<T>.collectOnce(coroutineScope: CoroutineScope, collect: (T) -> Unit) {
     coroutineScope.launch {
         this@collectOnce.cancellable().collect {
             collect(it)


### PR DESCRIPTION
## 🌱 변경 사항 및 이유
- collectOnce 확장함수 추가

## ✅ PR Point
- 파라미터로 coroutineScope(cancel시키기 위함), collect 동작을 받음
- flow를 cancellableFlow로 변환하고 collect 한번 이후 파라미터로 받은 coroutineScope를 cancel시킴

## ❗️ 참고 사항
- 예시)
```
   val f = flow<Int> {
            emit(1)
            delay(1000)
            emit(2)
            delay(1000)
            emit(3)
        }
    
    
     viewModelScope.launch {
         f.collect {
             println("$it")
         }
     }
    //1, 2, 3 모두 출력
    f.collectOnce(viewModelScope) {
         println("$it")
    }
    //1만 출력
```

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
